### PR TITLE
Added messaging when a class hasn't been loaded yet but we attempt to…

### DIFF
--- a/JLJSONMapping/Util/FABJLObjectMappingUtils.m
+++ b/JLJSONMapping/Util/FABJLObjectMappingUtils.m
@@ -32,8 +32,12 @@
         if (range.location != NSNotFound) {
             NSInteger startIndex = range.location + range.length;
             NSRange typeRange = NSMakeRange(startIndex, ([typeItem length] - 1) - startIndex);
-            NSString *typeString = [typeItem substringWithRange:typeRange];
-            Class classOfProperty = NSClassFromString(typeString);
+            NSString *className = [typeItem substringWithRange:typeRange];
+            Class classOfProperty = NSClassFromString(className);
+            if (!classOfProperty) {
+                NSString *exceptionMessage = [NSString stringWithFormat:@"class: %@ not loaded in runtime. To fix this, you can load it by referencing the class somewhere before using the mapper (calling [%@ class]), or you can add -ObjC to your linker flags", className, className];
+                @throw([NSException exceptionWithName:NSInternalInconsistencyException reason:exceptionMessage userInfo:nil]);
+            }
             return classOfProperty;
         }
     }


### PR DESCRIPTION
Added error message in the case where the mapper can't create a class due to it not being loaded yet: 
`Class: %@ not loaded in runtime. To fix this, you can load it by referencing the class somewhere before using the mapper (calling [%@ class]), or you can add -ObjC to your linker flags`
