### PR TITLE
Adding bitcode support:

### DIFF
--- a/JLJSONMapping.xcodeproj/project.pbxproj
+++ b/JLJSONMapping.xcodeproj/project.pbxproj
@@ -465,6 +465,7 @@
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				ENABLE_BITCODE = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -479,6 +480,10 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"-fembed-bitcode",
+					"-Wno-error=unused-command-line-argument",
+				);
 				SDKROOT = iphoneos;
 			};
 			name = Debug;
@@ -496,11 +501,16 @@
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = YES;
+				ENABLE_BITCODE = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
+				OTHER_CFLAGS = (
+					"-fembed-bitcode",
+					"-Wno-error=unused-command-line-argument",
+				);
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};


### PR DESCRIPTION
- Adding `-fembed-bitcode` to ensure bitcode is always emitted otherwise
  it will only emit placeholder markers
- Adding `-Wno-error=unused-command-line-argument` because
  `-fembed-bitcode` will take precendence over `embed-bitcode-marker`, which
  becomes unused and result in compilation error
